### PR TITLE
feat(controllers/announcement): impl GET /api/announcement

### DIFF
--- a/backend/dto/announcement.go
+++ b/backend/dto/announcement.go
@@ -6,6 +6,21 @@ type LastAnnouncement struct {
 }
 
 type CreateAnnouncement struct {
-	Title string `json:"title"`
+	Title   string `json:"title"`
 	Content string `json:"content"`
+}
+
+type Announcement struct {
+	Id       int    `json:"id"`
+	Author   string `json:"author"`
+	Avatar   string `json:"avatar"`
+	AuthorId int    `json:"author_id"`
+	Title    string `json:"title"`
+	Abstract string `json:"abstract"`
+}
+
+type AnnouncementPage struct {
+	Pages         int            `json:"pages"`
+	Size          int            `json:"size"`
+	Announcements []Announcement `json:"announcements"`
 }

--- a/backend/models/announcement.go
+++ b/backend/models/announcement.go
@@ -8,4 +8,5 @@ type Announcement struct {
 	Abstract string
 	Content string	 `binding:"required"`
 	UserID uint
+	User User
 }

--- a/backend/models/user.go
+++ b/backend/models/user.go
@@ -6,10 +6,11 @@ import "gorm.io/gorm"
 // It contains the user's username, password, email, and permission level.
 type User struct {
 	gorm.Model
-	Username   string `gorm:"unique"`
-	Password   string
-	Email      string
-	Permission uint32       `gorm:"default:0"`                          
-	Problems   []Problem `json:"problems" gorm:"foreignKey:AuthorID"` // one-to-many relationship
+	Username     string `gorm:"unique"`
+	Avatar       string
+	Password     string
+	Email        string
+	Permission   uint32    `gorm:"default:0"`
+	Problems     []Problem `json:"problems" gorm:"foreignKey:AuthorID"` // one-to-many relationship
 	Announcement []Announcement
 }

--- a/backend/router/router.go
+++ b/backend/router/router.go
@@ -51,6 +51,7 @@ func SetupRouter() *gin.Engine {
 	announcement.Use(middlewares.AuthMiddleware())
 	{
 		announcement.POST("", controllers.CreateAnnouncement)
+		announcement.GET("",controllers.GetAnnouncement)
 	}
 	return fashOJBackendRouter
 }


### PR DESCRIPTION
feat(controllers/announcement): implement GET /api/announcement endpoint

## Description
This PR implements the GET /api/announcement endpoint in the announcement controller to retrieve a paginated list of announcements with author information.

## Changes
- Added GET /api/announcement endpoint handler in announcement controller
- Implemented pagination support with query parameters:
  - `page` (default: 1)
  - `size` (default: 10, max: 100)
- Added proper error handling for database operations
- Included response format with:
  - Total pages count
  - Current page size
  - List of announcements containing:
    - Title
    - Abstract
    - Author name
    - Author ID
    - Author avatar